### PR TITLE
Ensure concurrent instances don't run on the same port

### DIFF
--- a/source/RedisInside/Redis.cs
+++ b/source/RedisInside/Redis.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
 using System.Text;
@@ -93,13 +94,19 @@ namespace RedisInside
 
         private class Config : IConfig
         {
+            private static readonly ConcurrentDictionary<int, byte> usedPorts = new ConcurrentDictionary<int, byte>();
             private static readonly Random random = new Random();
             internal Action<string> logger;
             internal int port;
 
             public Config()
             {
-                port = random.Next(49152, 65535 + 1);
+                do
+                {
+                    port = random.Next(49152, 65535 + 1);
+                } while (usedPorts.ContainsKey(port));
+
+                usedPorts.AddOrUpdate(port, i => byte.MinValue, (i, b) => byte.MinValue);
                 logger = message => Trace.WriteLine(message);
             }
 


### PR DESCRIPTION
When running concurrent tests there is a chance (albeit small, but given enough test runs it will eventually happen) that two instances will try to run on the same port. This is a simple fix for that.

A more elegant solution would be to remove the used ports as instances are disposed but that would require a larger re-write. I can implement that if you think it's worth the added complexity :)