### PR TITLE
Wait for Redis to start accepting connections

### DIFF
--- a/source/RedisInside.Tests/RedisTests.cs
+++ b/source/RedisInside.Tests/RedisTests.cs
@@ -48,6 +48,24 @@ namespace RedisInside.Tests
         }
 
         [Test]
+        public void Starting_multiple_on_same_port_yields_error()
+        {
+            // By using the same exact TCP port for both instances we
+            // guarantee that the second one will fail to initialize.
+            void Config(IConfig c) => c.Port(65530);
+
+            using (var redis = new Redis(Config))
+            {
+                Assert.Throws<System.InvalidOperationException>(() => {
+                    using (var redis2 = new Redis(Config))
+                    {
+                        Assert.Fail("redis2 should not have been created");
+                    }
+                });
+            }
+        }
+
+        [Test]
         public async Task Can_start_slave()
         {
 

--- a/source/RedisInside/Redis.cs
+++ b/source/RedisInside/Redis.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
 using System.Text;
+using System.Threading;
 using RedisInside.Executables;
 
 namespace RedisInside
@@ -13,9 +14,13 @@ namespace RedisInside
     public class Redis : IDisposable
     {
         private bool _disposed;
-        private readonly Process process;
+        private readonly Process process = new Process();
         private readonly TemporaryFile executable;
         private readonly Config config = new Config();
+        /// <summary>
+        /// An event that will be signaled when the Redis server is ready to accept TCP connections.
+        /// </summary>
+        private readonly ManualResetEventSlim serverReady = new ManualResetEventSlim();
 
         public Redis(Action<IConfig> configuration = null)
         {
@@ -24,7 +29,7 @@ namespace RedisInside
 
             executable = new TemporaryFile(typeof(RessourceTarget).Assembly.GetManifestResourceStream(typeof(RessourceTarget), "redis-server.exe"), "exe");
 
-            var processStartInfo = new ProcessStartInfo(" \"" + executable.Info.FullName + " \"")
+            process.StartInfo = new ProcessStartInfo(" \"" + executable.Info.FullName + " \"")
             {
                 UseShellExecute = false,
                 Arguments = string.Format("--port {0} --bind 127.0.0.1 --persistence-available no", config.port),
@@ -36,10 +41,54 @@ namespace RedisInside
                 StandardOutputEncoding = Encoding.ASCII,
             };
 
-            process = Process.Start(processStartInfo);
             process.ErrorDataReceived += (sender, eventargs) => config.logger.Invoke(eventargs.Data);
             process.OutputDataReceived += (sender, eventargs) => config.logger.Invoke(eventargs.Data);
+
+            process.OutputDataReceived += DetectServerReady;
+
+            void ProcessExitedHandler(object sender, EventArgs eventargs) =>
+                throw new InvalidOperationException("The Redis process terminated unexpectedly.");
+
+            process.EnableRaisingEvents = true; // The Exited event is only raised if this flag is set to `true` :)
+            process.Exited += ProcessExitedHandler;
+
+            process.Start();
+
             process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            WaitForRedisOrThrow();
+
+            process.Exited -= ProcessExitedHandler;
+            process.OutputDataReceived -= DetectServerReady;
+        }
+
+        /// <summary>
+        /// Listens to stdout from the spawned instance of Redis and detects when it is ready to accept connections.
+        /// </summary>
+        private void DetectServerReady(object sender, DataReceivedEventArgs e)
+        {
+            if (!String.IsNullOrWhiteSpace(e?.Data) && e.Data.Contains("now ready to accept connections"))
+            {
+                serverReady.Set(); // Signal that it is now safe to consume this instance of Redis
+            }
+        }
+
+        /// <summary>
+        /// Waits up to 5 seconds for the Redis server to become available. Throws if Redis never reports that it is
+        /// ready to start accepting connections within this time. Returns immediately once the server is ready.
+        /// </summary>
+        private void WaitForRedisOrThrow()
+        {
+            TimeSpan timeToWait = TimeSpan.FromSeconds(5);
+
+            bool isServerReady = serverReady.Wait(timeToWait);
+
+            if (!isServerReady)
+            {
+                var exnMessage = String.Format("The Redis server failed to become available after {0:0} seconds.", timeToWait.TotalSeconds);
+                throw new InvalidOperationException(exnMessage);
+            }
         }
 
         [Obsolete("Use Endpoint Instead")]


### PR DESCRIPTION
Previously the `RedisInside.Redis` ctor would return immediately after
invoking the Redis server executable. In the event that the server was
unable to start (e.g. bind failure on the given TCP port) the consumer
of RedisInside would not know about this failure until they attempted to
connect to it. Now RedisInside will throw if the Redis server does not
start up. This should make it easier for consumers to retry failed
operations.